### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/stock_env/Lib/site-packages/pyautogen-0.7.5.dist-info/METADATA
+++ b/stock_env/Lib/site-packages/pyautogen-0.7.5.dist-info/METADATA
@@ -1,5 +1,5 @@
 Metadata-Version: 2.4
-Name: pyautogen
+Name: ag2
 Version: 0.7.5
 Summary: A programming framework for agentic AI
 Project-URL: Homepage, https://ag2.ai/
@@ -10,7 +10,7 @@ Project-URL: Discord, https://discord.gg/pAbnFJrkgZ
 Author-email: Chi Wang & Qingyun Wu <support@ag2.ai>
 License-File: LICENSE
 License-File: NOTICE.md
-Keywords: ag2,ag2.ai,ag2ai,agent,agentic,ai,autogen,pyautogen
+Keywords: ag2,ag2.ai,ag2ai,agent,agentic,ai,autogen,ag2
 Classifier: Development Status :: 5 - Production/Stable
 Classifier: Intended Audience :: Developers
 Classifier: Intended Audience :: Information Technology
@@ -265,7 +265,7 @@ Description-Content-Type: text/markdown
   <img src="https://raw.githubusercontent.com/ag2ai/ag2/27b37494a6f72b1f8050f6bd7be9a7ff232cf749/website/static/img/ag2.svg" width="150" title="hover text">
   <br>
   <br>
-  <img src="https://img.shields.io/pypi/dm/pyautogen?label=PyPI%20downloads">
+  <img src="https://img.shields.io/pypi/dm/ag2?label=PyPI%20downloads">
   <a href="https://badge.fury.io/py/autogen"><img src="https://badge.fury.io/py/autogen.svg"></a>
   <a href="https://github.com/ag2ai/ag2/actions/workflows/python-package.yml">
     <img src="https://github.com/ag2ai/ag2/actions/workflows/python-package.yml/badge.svg">
@@ -325,7 +325,7 @@ For a step-by-step walk through of AG2 concepts and code, see [Basic Concepts](h
 
 ### Installation
 
-AG2 requires **Python version >= 3.9, < 3.14**. AG2 is available via `ag2` (or its alias `pyautogen` or `autogen`) on PyPI.
+AG2 requires **Python version >= 3.9, < 3.14**. AG2 is available via `ag2` (or its alias `ag2` or `autogen`) on PyPI.
 
 ```bash
 pip install ag2


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
